### PR TITLE
lib: move from asm! to llvm_asm!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libos"
 description = "Library OS"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["KarimAllah Ahmed <karim.allah.ahmed@gmail.com>"]
 edition = "2018"
 documentation = "https://docs.rs/libos"
@@ -18,6 +18,6 @@ categories = [
 ]
 
 [dependencies]
-x86_64 = "0.7.5"
+x86_64 = "0.11.0"
 lazy_static = { version = "1.3.0", features = ["spin_no_std"] }
-bootloader = { version = "0.6.4", features = ["map_physical_memory"]}
+bootloader = { version = "0.9.4", features = ["map_physical_memory"]}

--- a/src/idt.rs
+++ b/src/idt.rs
@@ -14,7 +14,7 @@ lazy_static! {
         idt[35].set_handler_fn(ipi_handler);
         idt[39].set_handler_fn(spurious_handler);
 
-        idt.divide_by_zero.set_handler_fn(generic_handler);
+        idt.divide_error.set_handler_fn(generic_handler);
         idt.debug.set_handler_fn(generic_handler);
         idt.non_maskable_interrupt.set_handler_fn(generic_handler);
         idt.breakpoint.set_handler_fn(generic_handler);
@@ -23,7 +23,7 @@ lazy_static! {
         idt.invalid_opcode.set_handler_fn(generic_handler);
         idt.device_not_available.set_handler_fn(generic_handler);
         idt.x87_floating_point.set_handler_fn(generic_handler);
-        idt.machine_check.set_handler_fn(generic_handler);
+        idt.machine_check.set_handler_fn(machine_check_handler);
         idt.virtualization.set_handler_fn(generic_handler);
         idt.double_fault.set_handler_fn(double_fault_handler);
 
@@ -51,7 +51,7 @@ extern "x86-interrupt" fn pagefault_handler(
 
 extern "x86-interrupt" fn double_fault_handler(
     _stack_frame: &mut InterruptStackFrame,
-    error_code: u64)
+    error_code: u64) -> !
 {
     println!("double fault -> error: {:?}", error_code);
     println!("fault_address {:?}", x86_64::registers::control::Cr2::read());
@@ -85,6 +85,13 @@ extern "x86-interrupt" fn generic_handler(
     _stack_frame: &mut InterruptStackFrame)
 {
     println!("Generic handler!");
+    loop {}
+}
+
+extern "x86-interrupt" fn machine_check_handler(
+    _stack_frame: &mut InterruptStackFrame) -> !
+{
+    println!("Machine check handler!");
     loop {}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![feature(asm)]
+#![feature(llvm_asm)]
 #![feature(abi_x86_interrupt)]
 #![feature(alloc_error_handler)]
 

--- a/src/msr.rs
+++ b/src/msr.rs
@@ -32,7 +32,7 @@ impl MSR {
         let low: u32;
         let high: u32;
 
-        asm!("rdmsr" : "={eax}" (low), "={edx}" (high) : "{ecx}" (*self) : "memory" : "volatile");
+        llvm_asm!("rdmsr" : "={eax}" (low), "={edx}" (high) : "{ecx}" (*self) : "memory" : "volatile");
         ((high as u64) << 32) | (low as u64)
     }
 
@@ -40,6 +40,6 @@ impl MSR {
         let low = value as u32;
         let high = (value >> 32) as u32;
 
-        asm!("wrmsr" :: "{ecx}" (*self), "{eax}" (low), "{edx}" (high) : "memory" : "volatile" );
+        llvm_asm!("wrmsr" :: "{ecx}" (*self), "{eax}" (low), "{edx}" (high) : "memory" : "volatile" );
     }
 }

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["KarimAllah Ahmed <karim.allah.ahmed@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-bootloader = { version = "0.6.4", features = ["map_physical_memory"]}
-x86_64 = "0.7.5"
+bootloader = { version = "0.9.4", features = ["map_physical_memory"]}
+x86_64 = "0.11.0"
 rlibc = "1.0.0"
 libos = { path = "../../libos" }
 lazy_static = { version = "1.3.0", features = ["spin_no_std"] }


### PR DESCRIPTION
Current project does not compile with rust 1.46 nightly because of new
asm syntax.

Rust 1.46 nightly introduced a new asm syntax and move the old syntax
under a new feature called llvm_asm. Since this feature is more like an
RFC let's not move to this new asm syntax instead use llvm_asm
everywhere.

More details can be found here:
https://blog.rust-lang.org/inside-rust/2020/06/08/new-inline-asm.htmlA

While at it I also need to bump few dependencies to new version
because they were also old asm implementation. And create a new minor
release for libos project

Signed-off-by: Jinank Jain <jinank94@gmail.com>